### PR TITLE
refactor: use Promises instead of asynchronous callbacks to load data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ import { feedGdax } from 'd3fc-financial-feed';
 const gdax = feedGdax()
   .product('BTC-GBP');
 
-gdax((error, data) => {
-  if (error) throw error;
-  console.log(data);
-});
+gdax()
+  .then(data => { console.log(data); });
 
 // [
 //   {
@@ -47,10 +45,9 @@ https://docs.gdax.com/#get-historic-rates
 
 Constructs a new GDAX feed.
 
-<a name="feedGdax_" href="#feedGdax_">#</a> *feedGdax*(*callback*)
+<a name="feedGdax_" href="#feedGdax_">#</a> *feedGdax*()
 
-Makes a request to the GDAX API, with *callback* invoked when the request succeeds or fails.
-The callback is invoked with two arguments: the error, if any, and the data.
+Makes a request to the GDAX API, returns a `Promise` which resolves with data.
 Data returned from the API is mapped to an array of objects with numeric
 `open`, `high`, `low`, `close` and `volume` properties, and a `Date` instance `date` property.
 
@@ -87,10 +84,8 @@ const quandl = feedQuandl()
   .descending(true)
   .collapse('weekly');
 
-quandl((error, data) => {
-  if (error) throw error;
-  console.log(data);
-});
+quandl()
+  .then(data => { console.log(data); });
 
 // [
 //   {
@@ -118,10 +113,9 @@ https://www.quandl.com/docs/api#datasets
 
 Constructs a new quandl feed.
 
-<a name="feedQuandl_" href="#feedQuandl_">#</a> *feedQuandl*(*callback*)
+<a name="feedQuandl_" href="#feedQuandl_">#</a> *feedQuandl*()
 
-Makes a request to the Quandl API, with *callback* invoked when the request succeeds or fails.
-The callback is invoked with two arguments: the error, if any, and the data.
+Makes a request to the Quandl API, returns a `Promise` which resolves with data.
 Data returned from the API is mapped to an array of objects with properties for all non-null names mapped by *feedQuandl*.columnNameMap, with date column values converted to `Date` instances.
 
 <a name="feedQuandl_database" href="#feedQuandl_database">#</a> *feedQuandl*.**database**([*value*])

--- a/d3fc-financial-feed.d.ts
+++ b/d3fc-financial-feed.d.ts
@@ -22,7 +22,7 @@ declare namespace fc_financial_feed {
         granularity(): number;
         granularity(x: number): Gdax;
 
-        (callback: (error: any, data?: GdaxDatum[]) => void);
+        (): Promise<GdaxDatum[]>;
     }
 
     interface Quandl {
@@ -46,7 +46,7 @@ declare namespace fc_financial_feed {
         columnNameMap(mapFunction: (name: string) => string): Quandl;
         defaultColumnNameMap: (name: string) => string;
 
-        (callback: (error: any, data?: any[]) => void);
+        (): Promise<any[]>;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "d3fc-scripts": "^1.6.1"
   },
   "dependencies": {
-    "d3-request": "^1.0.1"
+    "d3-fetch": "^1.1.0"
   }
 }

--- a/src/gdax.js
+++ b/src/gdax.js
@@ -1,4 +1,4 @@
-import { json } from 'd3-request';
+import { json } from 'd3-fetch';
 
 // https://docs.gdax.com/#market-data
 export default function() {
@@ -8,7 +8,7 @@ export default function() {
     var end = null;
     var granularity = null;
 
-    var gdax = function(cb) {
+    var gdax = function() {
         var params = [];
         if (start != null) {
             params.push('start=' + start.toISOString());
@@ -20,23 +20,19 @@ export default function() {
             params.push('granularity=' + granularity);
         }
         var url = 'https://api.gdax.com/products/' + product + '/candles?' + params.join('&');
-        json(url, function(error, data) {
-            if (error) {
-                cb(error);
-                return;
-            }
-            data = data.map(function(d) {
-                return {
-                    date: new Date(d[0] * 1000),
-                    open: d[3],
-                    high: d[2],
-                    low: d[1],
-                    close: d[4],
-                    volume: d[5]
-                };
+        return json(url)
+            .then(function(data) {
+                return data.map(function(d) {
+                    return {
+                        date: new Date(d[0] * 1000),
+                        open: d[3],
+                        high: d[2],
+                        low: d[1],
+                        close: d[4],
+                        volume: d[5]
+                    };
+                });
             });
-            cb(error, data);
-        });
     };
 
     gdax.product = function(x) {

--- a/test/bundleSpec.js
+++ b/test/bundleSpec.js
@@ -6,22 +6,17 @@ describe('bundle', function() {
             html: '<html></html>',
             virtualConsole: jsdom.createVirtualConsole().sendTo(console),
             scripts: [
-                // transitive dependencies
-                './node_modules/d3-collection/build/d3-collection.js',
-                './node_modules/d3-dispatch/build/d3-dispatch.js',
-                './node_modules/d3-dsv/build/d3-dsv.js',
                 // direct dependencies
-                './node_modules/d3-request/build/d3-request.js',
+                './node_modules/d3-fetch/dist/d3-fetch.js',
                 './build/d3fc-financial-feed.js'
             ],
             done: (_, win) => {
-                const gdaxFeed = win.fc.feedGdax()
-                  .product('BTC-GBP');
+                const gdaxFeed = win.fc.feedGdax();
+                const quandlFeed = win.fc.feedQuandl();
 
-                gdaxFeed((_, data) => {
-                    expect(data).not.toBeUndefined();
-                    done();
-                });
+                expect(gdaxFeed).toBeDefined();
+                expect(quandlFeed).toBeDefined();
+                done();
             }
         });
     });


### PR DESCRIPTION
BREAKING CHANGE: this change replaces [d3-request](https://github.com/d3/d3-request) with [d3-fetch](https://github.com/d3/d3-fetch). A Promise interface is now used to fetch data. With the adoption of Promises, the [Fetch API](https://fetch.spec.whatwg.org/) is now used, instead of [XMLHttpRequest](https://developer.mozilla.org/docs/Web/API/XMLHttpRequest). As of this change, D3 v4 is incompatible with this package; [D3 v5](https://github.com/d3/d3/releases/tag/v5.0.0) is required.

Resolves #17 